### PR TITLE
implement a converter to support enumMember value

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AiCompletion/CompletionRequest.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AiCompletion/CompletionRequest.cs
@@ -6,7 +6,7 @@ namespace Azure.Sdk.Tools.Cli.Models.AiCompletion
     public class CompletionRequest
     {
         [JsonPropertyName("tenant_id")]
-        public string TenantId { get; set; } = "azure_sdk_qa_bot";
+        public TenantId TenantId { get; set; } = TenantId.AzureSDKQaBot;
 
         [JsonPropertyName("prompt_template")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AiCompletion/Enums.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AiCompletion/Enums.cs
@@ -1,9 +1,10 @@
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
+using Azure.Sdk.Tools.Cli.Models.seraialize;
 
 namespace Azure.Sdk.Tools.Cli.Models.AiCompletion
 {
-    [JsonConverter(typeof(JsonStringEnumConverter<TenantId>))]
+    [JsonConverter(typeof(JsonStringEnumWithEnumMemberConverter<TenantId>))]
     public enum TenantId
     {
         [EnumMember(Value = "azure_sdk_qa_bot")]
@@ -19,7 +20,7 @@ namespace Azure.Sdk.Tools.Cli.Models.AiCompletion
         AzureSDKOnboarding
     }
 
-    [JsonConverter(typeof(JsonStringEnumConverter<Source>))]
+    [JsonConverter(typeof(JsonStringEnumWithEnumMemberConverter<Source>))]
     public enum Source
     {
         [EnumMember(Value = "typespec_docs")]
@@ -62,7 +63,7 @@ namespace Azure.Sdk.Tools.Cli.Models.AiCompletion
         TypeSpecHttpSpecs
     }
 
-    [JsonConverter(typeof(JsonStringEnumConverter<Role>))]
+    [JsonConverter(typeof(JsonStringEnumWithEnumMemberConverter<Role>))]
     public enum Role
     {
         [EnumMember(Value = "user")]
@@ -75,7 +76,7 @@ namespace Azure.Sdk.Tools.Cli.Models.AiCompletion
         System
     }
 
-    [JsonConverter(typeof(JsonStringEnumConverter<AdditionalInfoType>))]
+    [JsonConverter(typeof(JsonStringEnumWithEnumMemberConverter<AdditionalInfoType>))]
     public enum AdditionalInfoType
     {
         [EnumMember(Value = "link")]
@@ -85,7 +86,7 @@ namespace Azure.Sdk.Tools.Cli.Models.AiCompletion
         Image
     }
 
-    [JsonConverter(typeof(JsonStringEnumConverter<QuestionScope>))]
+    [JsonConverter(typeof(JsonStringEnumWithEnumMemberConverter<QuestionScope>))]
     public enum QuestionScope
     {
         [EnumMember(Value = "unknown")]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/seraialize/JsonStringEnumWithEnumMemberConverter.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/seraialize/JsonStringEnumWithEnumMemberConverter.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models.seraialize
+{
+    public class JsonStringEnumWithEnumMemberConverter<T> : JsonConverter<T> where T : struct, Enum
+    {
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            foreach (var field in typeof(T).GetFields())
+            {
+                var attr = field.GetCustomAttribute<EnumMemberAttribute>();
+                if (attr?.Value == value)
+                {
+                    var ret = field.GetValue(null);
+                    return ret != null ? (T)ret : default;
+                }
+            }
+            return Enum.Parse<T>(value);
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            var field = typeof(T).GetField(value.ToString());
+            if (field == null)
+            {
+                writer.WriteStringValue(value.ToString());
+            } else
+            {
+                var attr = field.GetCustomAttribute<EnumMemberAttribute>();
+                writer.WriteStringValue(attr?.Value ?? field.Name);
+            }
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/AiCompletionTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/AiCompletionTool.cs
@@ -159,7 +159,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
                 // Build request
                 var request = new CompletionRequest
                 {
-                    TenantId = "azure_sdk_qa_bot",
+                    TenantId = TenantId.AzureSDKQaBot,
                     Message = new Message
                     {
                         Role = Role.User,
@@ -280,7 +280,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
                 // Build request
                 var request = new CompletionRequest
                 {
-                    TenantId = "azure_sdk_qa_bot",
+                    TenantId = TenantId.AzureSDKQaBot,
                     Message = new Message
                     {
                         Role = Role.User,


### PR DESCRIPTION
When serializing a `CompletionRequest` instance to HTTP content, enum properties such as `Source` or `Role` are not converted to the string values defined in their [EnumMember(Value = "...")] attributes (see example below).
To address this, we will implement a custom enum JSON converter named JsonStringEnumWithEnumMemberConverter that ensures enum values are serialized using their EnumMember values.

e.g.
current:

[RequestID: 64a37bf6-bed0-46c1-8097-6aaebde1644e] 2025/09/02 02:45:04 Request: {"tenant_id":"azure_sdk_qa_bot","prompt_template":null,"prompt_template_arguments":null,"top_k":15,"sources":******["**TypeSpec**","**TypeSpecAzure**","**AzureRestAPISpec**"**]**,**"message":{"role":"**User"**,"content":"What are the TypeSpec versioning decorators like @added, @removed, @typeChangedFrom? How do you handle property changes between API versions in TypeSpec Azure specifications?"},"history":null,"with_full_context":false,"with_preprocess":null}

expected:

[RequestID: 64a37bf6-bed0-46c1-8097-6aaebde1644e] 2025/09/02 02:45:04 Request: {"tenant_id":"azure_sdk_qa_bot","prompt_template":null,"prompt_template_arguments":null,"top_k":15,"sources":****["**typespec_docs**","**typespec_azure_docs**","**azure_rest_api_specs_wiki**"]**,**"message":{"role":"**user**","content":"What are the TypeSpec versioning decorators like @added, @removed, @typeChangedFrom? How do you handle property changes between API versions in TypeSpec Azure specifications?"},"history":null,"with_full_context":false,"with_preprocess":null}

