### PR TITLE
remove sources and TopK parameter

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Options/AiCompletionOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Options/AiCompletionOptions.cs
@@ -28,7 +28,7 @@ namespace Azure.Sdk.Tools.Cli.Options
     /// Timeout for HTTP requests in seconds. Default is 30 seconds.
     /// </summary>
     [Range(1, 300)]
-    public int TimeoutSeconds { get; set; } = 30;
+    public int TimeoutSeconds { get; set; } = 300;
 
     /// <summary>
     /// Maximum number of retry attempts for failed requests. Default is 3.


### PR DESCRIPTION
When use mcp  by agent, agent will pass parameter sources, topK, and actually sources are calculated by chat bot according to the tenant. If you provide sources, it will used it, but actually it is not correct in most time.